### PR TITLE
Adding \ to core class usage in order to make it usable with namespace

### DIFF
--- a/EpiOAuth.php
+++ b/EpiOAuth.php
@@ -418,7 +418,7 @@ class EpiOAuthResponse
   }
 }
 
-class EpiOAuthException extends Exception
+class EpiOAuthException extends \Exception
 {
   public static function raise($response, $debug)
   {

--- a/EpiTwitter.php
+++ b/EpiTwitter.php
@@ -149,7 +149,7 @@ class EpiTwitter extends EpiOAuth
   }
 }
 
-class EpiTwitterJson implements ArrayAccess, Countable, IteratorAggregate
+class EpiTwitterJson implements \ArrayAccess, \Countable, \IteratorAggregate
 {
   private $debug;
   private $__resp;
@@ -242,7 +242,7 @@ class EpiTwitterJson implements ArrayAccess, Countable, IteratorAggregate
   }
 }
 
-class EpiTwitterException extends Exception 
+class EpiTwitterException extends \Exception 
 {
   public static function raise($response, $debug)
   {


### PR DESCRIPTION
I needed this for one of my script, and I think it's quite a good practice to do so.
