### PR TITLE
Updated Twitter API version to 1.1

### DIFF
--- a/EpiTwitter.php
+++ b/EpiTwitter.php
@@ -22,7 +22,7 @@ class EpiTwitter extends EpiOAuth
   protected $apiVersionedUrl= 'http://api.twitter.com';
   protected $searchUrl      = 'http://search.twitter.com';
   protected $userAgent      = 'EpiTwitter (http://github.com/jmathai/twitter-async/tree/)';
-  protected $apiVersion     = '1';
+  protected $apiVersion     = '1.1';
   protected $isAsynchronous = false;
 
   /* OAuth methods */


### PR DESCRIPTION
Twitter API version 1 is deprecated and so it was returning page not found error. So updated the version to 1.1. 
Regards,
Kishan
