### PR TITLE
Twitter API Version 1.1 Support

### DIFF
--- a/EpiTwitter.php
+++ b/EpiTwitter.php
@@ -18,11 +18,10 @@ class EpiTwitter extends EpiOAuth
   protected $accessTokenUrl = 'https://api.twitter.com/oauth/access_token';
   protected $authorizeUrl   = 'https://api.twitter.com/oauth/authorize';
   protected $authenticateUrl= 'https://api.twitter.com/oauth/authenticate';
-  protected $apiUrl         = 'http://api.twitter.com';
-  protected $apiVersionedUrl= 'http://api.twitter.com';
-  protected $searchUrl      = 'http://search.twitter.com';
+  protected $apiUrl         = 'https://api.twitter.com/1.1';
+  protected $apiVersionedUrl= 'https://api.twitter.com';
   protected $userAgent      = 'EpiTwitter (http://github.com/jmathai/twitter-async/tree/)';
-  protected $apiVersion     = '1';
+  protected $apiVersion     = '1.1';
   protected $isAsynchronous = false;
 
   /* OAuth methods */
@@ -103,9 +102,7 @@ class EpiTwitter extends EpiOAuth
 
   private function getApiUrl($endpoint)
   {
-    if(preg_match('@^/search[./]?(?=(json|daily|current|weekly))@', $endpoint))
-      return "{$this->searchUrl}{$endpoint}";
-    elseif(!empty($this->apiVersion))
+    if (! empty($this->apiVersion))
       return "{$this->apiVersionedUrl}/{$this->apiVersion}{$endpoint}";
     else
       return "{$this->apiUrl}{$endpoint}";


### PR DESCRIPTION
The search endpoint is no longer a separate URI (https://dev.twitter.com/docs/api/1.1). Everything else seems to work as expected, as long as oAuth credentials are used. I have tested this with almost all GET endpoints, but not with any POST endpoints.
