### PR TITLE
Twitter API Version 1.1 Support

### DIFF
--- a/EpiTwitter.php
+++ b/EpiTwitter.php
@@ -111,7 +111,12 @@ class EpiTwitter extends EpiOAuth
 
   private function getApiUrl($endpoint)
   {
-    return "{$this->apiUrl}/{$this->apiVersion}{$endpoint}";
+    if ($this->apiVersion === '1' && preg_match('@^/search[./]?(?=(json|daily|current|weekly))@', $endpoint))
+    {
+      return $this->searchUrl.$endpoint;
+    }
+
+    return $this->apiUrl.'/'.$this->apiVersion.$endpoint;
   }
 
   private function request($method, $endpoint, $params = null)


### PR DESCRIPTION
The search endpoint is no longer a separate URI (https://dev.twitter.com/docs/api/1.1). Everything else seems to work as expected, as long as oAuth credentials are used. I have tested this with almost all GET endpoints, but not with any POST endpoints.
