### PR TITLE
Update api url to https.

### DIFF
--- a/EpiTwitter.php
+++ b/EpiTwitter.php
@@ -18,7 +18,7 @@ class EpiTwitter extends EpiOAuth
   protected $accessTokenUrl = 'https://api.twitter.com/oauth/access_token';
   protected $authorizeUrl   = 'https://api.twitter.com/oauth/authorize';
   protected $authenticateUrl= 'https://api.twitter.com/oauth/authenticate';
-  protected $apiUrl         = 'http://api.twitter.com';
+  protected $apiUrl         = 'https://api.twitter.com';
   protected $userAgent      = 'EpiTwitter (http://github.com/jmathai/twitter-async/tree/)';
   protected $apiVersion     = '1.1';
   protected $isAsynchronous = false;


### PR DESCRIPTION
On January 14th, 2014, connections to api.twitter.com will be restricted to TLS/SSL connections only.
